### PR TITLE
feat(lint) replace deprecated golint with golangci-lint

### DIFF
--- a/stepCheck.go
+++ b/stepCheck.go
@@ -58,13 +58,13 @@ func (c *StepCheck) GetCommand() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := CommandDurationWrapper(cmd, func() error {
 				ColorPrintln("Checking", HGreen)
-				// golint
+				// golangci-lint
 				if *c.Lint {
-					if err := EnsureTool("golint", "golang.org/x/lint/golint"); err != nil {
+					if err := EnsureTool("golangci-lint", "github.com/golangci/golangci-lint/v2"); err != nil {
 						return err
 					}
 					ColorPrintln("lint", Magenta)
-					if err := ExecShell("./dist-tools/golint $(go list ./... | grep -v '/vendor/') | grep -v 'should have comment or be unexported' || true"); err != nil {
+					if err := ExecShell("./dist-tools/golangci-lint run ./... || true"); err != nil {
 						return errs.WithE(err, "lint failed")
 					}
 				}

--- a/tools.go
+++ b/tools.go
@@ -7,5 +7,5 @@ import (
 	_ "github.com/fzipp/gocyclo"
 	_ "github.com/go-bindata/go-bindata/go-bindata"
 	_ "github.com/gordonklaus/ineffassign"
-	_ "golang.org/x/lint/golint"
+	_ "github.com/golangci/golangci-lint/v2"
 )


### PR DESCRIPTION
Run golangci-lint with default options and linters. Enabled linters & formatters are:
* errcheck: Errcheck is a program for checking for unchecked errors in Go code. These unchecked errors can be critical bugs in some cases.
* govet: Vet examines Go source code and reports suspicious constructs. It is roughly the same as 'go vet' and uses its passes. [auto-fix]
* ineffassign: Detects when assignments to existing variables are not used. [fast]
* staticcheck: It's the set of rules from staticcheck. [auto-fix]
* unused: Checks Go code for unused constants, variables, functions and types.